### PR TITLE
fix mmap in openjtalk mecab on _WIN32

### DIFF
--- a/openjtalk/mecab/config.h
+++ b/openjtalk/mecab/config.h
@@ -86,6 +86,7 @@
 
 /* Define to 1 if you have the <windows.h> header file. */
 /* #undef HAVE_WINDOWS_H */
+#define HAVE_WINDOWS_H 1
 
 /* Define to 1 if you have the `iconv_open' library(-liconv). */
 /* #undef ICONV_CONST */


### PR DESCRIPTION
When I compiled libvits-ncnn on the windows platform, I encountered undefined win32-related structures. I fixed this part by referring to the latest code of openjtalk. Now it is compiled and passed on the windows platform, and it can run normally.